### PR TITLE
Update addon version and remove python 2 support

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.youtube_channels" name="YouTube Channels" version="1.0.0" provider-name="Alexander Seiler">
+<addon id="script.module.youtube_channels" name="YouTube Channels" version="0.2.0" provider-name="Alexander Seiler">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="plugin.video.youtube" version="6.8.18+matrix.1"/>

--- a/addon.xml
+++ b/addon.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.youtube_channels" name="YouTube Channels" version="0.1.0" provider-name="Alexander Seiler">
+<addon id="script.module.youtube_channels" name="YouTube Channels" version="1.0.0" provider-name="Alexander Seiler">
   <requires>
-    <import addon="xbmc.python" version="2.25.0"/>
-    <import addon="plugin.video.youtube" version="6.4.0"/>
-    <import addon="script.module.simplecache" version="1.0.11"/>
-    <import addon="script.module.kodi-six" version="0.0.2"/>
+    <import addon="xbmc.python" version="3.0.0"/>
+    <import addon="plugin.video.youtube" version="6.8.18+matrix.1"/>
+    <import addon="script.module.simplecache" version="2.0.2"/>
   </requires>
   <extension point="xbmc.python.module" library="lib">
   </extension>

--- a/lib/dummycache.py
+++ b/lib/dummycache.py
@@ -1,6 +1,0 @@
-class SimpleCache:
-    def get(self, endpoint, checksum=""):
-        return None
-
-    def set(self, endpoint, data, checksum="", expiration=None):
-        pass

--- a/lib/youtube_channels.py
+++ b/lib/youtube_channels.py
@@ -21,19 +21,15 @@
 
 import traceback
 
-from kodi_six import xbmc, xbmcgui, xbmcplugin, xbmcaddon
+import xbmc
+import xbmcgui
+import xbmcplugin
+import xbmcaddon
 
 from youtube_plugin.kodion.utils import datetime_parser
 import youtube_requests
 
-import sys
-# NOTE: As soon as script.module.simplecache is Python 3 compatible,
-# we can remove the following condition and just import SimpleCache.
-# See https://github.com/kodi-community-addons/script.module.simplecache/pull/7
-if sys.version_info[0] >= 3:
-    from dummycache import SimpleCache
-else:
-    from simplecache import SimpleCache
+import simplecache
 
 
 ADDON_ID = 'script.module.youtube_channels'
@@ -44,14 +40,7 @@ ICON = REAL_SETTINGS.getAddonInfo('icon')
 
 VIDEOS_PER_PAGE = 50
 
-
-try:
-    CompatStr = unicode  # Python2
-except NameError:
-    CompatStr = str  # Python3
-
-
-def try_get(dictionary, keys, data_type=CompatStr, default=''):
+def try_get(dictionary, keys, data_type=str, default=''):
     """
     Accesses a nested dictionary in a save way.
 
@@ -87,7 +76,7 @@ class YoutubeChannels(object):
         self.plugin_id = plugin_id
         self.video_ids = []
 
-        self.cache = SimpleCache()
+        self.cache = simplecache.SimpleCache()
         self.debug = debug
 
     def log(self, msg, level=xbmc.LOGDEBUG):


### PR DESCRIPTION
This PR adds support for Matrix and removes Python 2.

Maybe we should create a separate branch for the Matrix version. @goggle What do you think?