### PR TITLE
Allow using of plugin.video.youtube 7.3.x

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.youtube_channels" name="YouTube Channels" version="0.2.0" provider-name="Alexander Seiler">
+<addon id="script.module.youtube_channels" name="YouTube Channels" version="0.2.0.1" provider-name="Alexander Seiler">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="plugin.video.youtube" version="6.8.18+matrix.1"/>

--- a/lib/youtube_channels.py
+++ b/lib/youtube_channels.py
@@ -26,7 +26,10 @@ import xbmcgui
 import xbmcplugin
 import xbmcaddon
 
-from youtube_plugin.kodion.utils import datetime_parser
+try:
+    from youtube_plugin.kodion.utils import datetime_parser
+except ImportError:
+    from youtube_plugin.kodion.utils import datetime as datetime_parser
 import youtube_requests
 
 import simplecache


### PR DESCRIPTION
The up-coming plugin.video.youtube 7.3.0 renamed the datetime_parser to datetime only. So, try to import the former before trying to import the later. Like that this script addon works with both the pre-7.3 and post-7.3 youtube plugin. I increased also a version to 0.2.0.1 so that one can eventually release.
I verified that the PlaySRF and PlayRTS work just fine with this change independent on the youtube plugin version. Without this fix, they don't start if the 7.3.0-beta* is installed.